### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/bosun-ai/async-anthropic/releases/tag/v0.1.0) - 2025-02-09
+
+### Added
+
+- Default api key to env
+
+### Fixed
+
+- Add tests
+
+### Other
+
+- Fix docs
+- Cleanup + Lint
+- Add CI
+- Simplify tool use api
+- Rename to async-anthropic
+- Update readme
+- Fix example for tool use
+- Simplify api and fix first example
+- Move types
+- Just rewrite the whole thing :tada:
+- Clean up dependencies and feature flags
+- Add note in readme
+- added tool choices
+- Add tool_choice
+- added builder
+- added error events
+- added error events
+- added error events
+- added error events
+- added error events
+- added metadata, stop_sequences, top_k and top_p
+- added metadata, stop_sequences, top_k and top_p
+- added more detailed error message
+- added verbose and tool-use
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial release
+- initial changes
+- initial changes
+- initial release
+- Initial commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,55 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Default api key to env
+- Client rewrite
 
 ### Fixed
 
 - Add tests
 
-### Other
-
-- Fix docs
-- Cleanup + Lint
-- Add CI
-- Simplify tool use api
-- Rename to async-anthropic
-- Update readme
-- Fix example for tool use
-- Simplify api and fix first example
-- Move types
-- Just rewrite the whole thing :tada:
-- Clean up dependencies and feature flags
-- Add note in readme
-- added tool choices
-- Add tool_choice
-- added builder
-- added error events
-- added error events
-- added error events
-- added error events
-- added error events
-- added metadata, stop_sequences, top_k and top_p
-- added metadata, stop_sequences, top_k and top_p
-- added more detailed error message
-- added verbose and tool-use
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial release
-- initial changes
-- initial changes
-- initial release
-- Initial commit


### PR DESCRIPTION



## 🤖 New release

* `async-anthropic`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/bosun-ai/async-anthropic/releases/tag/v0.1.0) - 2025-02-09

### Added

- Default api key to env

### Fixed

- Add tests

### Other

- Fix docs
- Cleanup + Lint
- Add CI
- Simplify tool use api
- Rename to async-anthropic
- Update readme
- Fix example for tool use
- Simplify api and fix first example
- Move types
- Just rewrite the whole thing :tada:
- Clean up dependencies and feature flags
- Add note in readme
- added tool choices
- Add tool_choice
- added builder
- added error events
- added error events
- added error events
- added error events
- added error events
- added metadata, stop_sequences, top_k and top_p
- added metadata, stop_sequences, top_k and top_p
- added more detailed error message
- added verbose and tool-use
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial release
- initial changes
- initial changes
- initial release
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).