### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/bosun-ai/async-anthropic/compare/v0.1.0...v0.2.0) - 2025-02-10
+
+### Added
+
+- Ensure all message content is accessible
+- Add convenience method to access first matching text content in message
+- Add convenience str to message conversion and partialeq
+
+### Other
+
+- release v0.1.0 (#2)
+
 ## [0.1.0](https://github.com/bosun-ai/async-anthropic/releases/tag/v0.1.0) - 2025-02-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "async-anthropic"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-anthropic"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Timon Vonk <timon@bosun.ai>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `async-anthropic`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `async-anthropic` breaking changes

```text
--- failure type_allows_fewer_generic_type_params: type now allows fewer generic type parameters ---

Description:
A type now allows fewer generic type parameters than it used to. Uses of this type that supplied all previously-supported generic types will be broken.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/type_allows_fewer_generic_type_params.ron

Failed in:
  Struct MessageContentList allows 1 -> 0 generic types in /tmp/.tmpt8I3pQ/async-anthropic/src/types.rs:57
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/bosun-ai/async-anthropic/compare/v0.1.0...v0.2.0) - 2025-02-10

### Added

- Ensure all message content is accessible
- Add convenience method to access first matching text content in message
- Add convenience str to message conversion and partialeq

### Other

- release v0.1.0 (#2)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).