### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/bosun-ai/async-anthropic/compare/v0.2.0...v0.2.1) - 2025-02-10
+
+### Added
+
+- Inner content of message list must be private
+- Also implement deref mut for message content list
+
 ## [0.2.0](https://github.com/bosun-ai/async-anthropic/compare/v0.1.0...v0.2.0) - 2025-02-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Inner content of message list must be private
+- Inner content of message list must be public
 - Also implement deref mut for message content list
 
 ## [0.2.0](https://github.com/bosun-ai/async-anthropic/compare/v0.1.0...v0.2.0) - 2025-02-10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "async-anthropic"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-anthropic"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Timon Vonk <timon@bosun.ai>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `async-anthropic`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/bosun-ai/async-anthropic/compare/v0.2.0...v0.2.1) - 2025-02-10

### Added

- Inner content of message list must be private
- Also implement deref mut for message content list
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).