### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/bosun-ai/async-anthropic/compare/v0.2.1...v0.3.0) - 2025-02-18
+
+### Added
+
+- Add backoff implementation (#5)
+
+### Other
+
+- Add backoff as a major feature
+
 ## [0.2.1](https://github.com/bosun-ai/async-anthropic/compare/v0.2.0...v0.2.1) - 2025-02-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "async-anthropic"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-anthropic"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Timon Vonk <timon@bosun.ai>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `async-anthropic`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `async-anthropic` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_variant_added.ron

Failed in:
  variant AnthropicError:ApiError in /tmp/.tmpHft3lO/async-anthropic/src/errors.rs:18
  variant AnthropicError:UnexpectedError in /tmp/.tmpHft3lO/async-anthropic/src/errors.rs:27
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/bosun-ai/async-anthropic/compare/v0.2.1...v0.3.0) - 2025-02-18

### Added

- Add backoff implementation (#5)

### Other

- Add backoff as a major feature
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).