### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/bosun-ai/async-anthropic/compare/v0.3.0...v0.4.0) - 2025-04-27
+
+### Added
+
+- Add support for models api
+- Convenience helpers for accessing message content
+- Implement streaming for messages api
+
+### Other
+
+- *(deps)* Bump the minor group with 7 updates ([#8](https://github.com/bosun-ai/async-anthropic/pull/8))
+- *(ci)* Add dependabot.yml
+
 ## [0.3.0](https://github.com/bosun-ai/async-anthropic/compare/v0.2.1...v0.3.0) - 2025-02-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "async-anthropic"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-anthropic"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Timon Vonk <timon@bosun.ai>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `async-anthropic`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `async-anthropic` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum async_anthropic::errors::CreateMessagesError, previously in file /tmp/.tmp9KEiaL/async-anthropic/src/errors.rs:4

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant AnthropicError:DeserializationError in /tmp/.tmp5p5BHY/async-anthropic/src/errors.rs:19
  variant AnthropicError:StreamError in /tmp/.tmp5p5BHY/async-anthropic/src/errors.rs:28
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/bosun-ai/async-anthropic/compare/v0.3.0...v0.4.0) - 2025-04-27

### Added

- Add support for models api
- Convenience helpers for accessing message content
- Implement streaming for messages api

### Other

- *(deps)* Bump the minor group with 7 updates ([#8](https://github.com/bosun-ai/async-anthropic/pull/8))
- *(ci)* Add dependabot.yml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).