### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/bosun-ai/async-anthropic/compare/v0.4.0...v0.5.0) - 2025-05-02
+
+### Added
+
+- Support streaming messages with tool use ([#10](https://github.com/bosun-ai/async-anthropic/pull/10))
+
+### Other
+
+- *(deps)* Bump reqwest from 0.12.9 to 0.12.15 in the minor group ([#9](https://github.com/bosun-ai/async-anthropic/pull/9))
+
 ## [0.4.0](https://github.com/bosun-ai/async-anthropic/compare/v0.3.0...v0.4.0) - 2025-04-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "async-anthropic"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-anthropic"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Timon Vonk <timon@bosun.ai>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `async-anthropic`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `async-anthropic` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant ContentBlockDelta:InputJsonDelta in /tmp/.tmpmBAhUC/async-anthropic/src/types.rs:308
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/bosun-ai/async-anthropic/compare/v0.4.0...v0.5.0) - 2025-05-02

### Added

- Support streaming messages with tool use ([#10](https://github.com/bosun-ai/async-anthropic/pull/10))

### Other

- *(deps)* Bump reqwest from 0.12.9 to 0.12.15 in the minor group ([#9](https://github.com/bosun-ai/async-anthropic/pull/9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).