### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/bosun-ai/async-anthropic/compare/v0.5.0...v0.6.0) - 2025-05-03
+
+### Added
+
+- Track input tokens when streaming
+
 ## [0.5.0](https://github.com/bosun-ai/async-anthropic/compare/v0.4.0...v0.5.0) - 2025-05-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "async-anthropic"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-anthropic"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Timon Vonk <timon@bosun.ai>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `async-anthropic`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `async-anthropic` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field usage of variant MessagesStreamEvent::MessageStart in /tmp/.tmpZ5VDa1/async-anthropic/src/types.rs:323

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct async_anthropic::types::MessageDeltaUsage, previously in file /tmp/.tmpCSMHK0/async-anthropic/src/types.rs:312
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/bosun-ai/async-anthropic/compare/v0.5.0...v0.6.0) - 2025-05-03

### Added

- Track input tokens when streaming
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).