### PR TITLE
Add User-Agent header to Anthropic API requests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -110,11 +110,11 @@ impl Client {
     }
 
     /// Call the messages api
-    pub fn messages(&self) -> Messages {
+    pub fn messages(&self) -> Messages<'_> {
         Messages::new(self)
     }
 
-    pub fn models(&self) -> Models {
+    pub fn models(&self) -> Models<'_> {
         Models::new(self)
     }
 
@@ -122,6 +122,12 @@ impl Client {
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert("x-api-key", self.api_key.expose_secret().parse().unwrap());
         headers.insert("anthropic-version", self.version.parse().unwrap());
+        headers.insert(
+            reqwest::header::USER_AGENT,
+            concat!("async-anthropic/", env!("CARGO_PKG_VERSION"))
+                .parse()
+                .unwrap(),
+        );
         if let Some(beta_value) = &self.beta {
             headers.insert("anthropic-beta", beta_value.parse().unwrap());
         }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -12,7 +12,7 @@ pub struct Messages<'c> {
 }
 
 impl Messages<'_> {
-    pub fn new(client: &Client) -> Messages {
+    pub fn new(client: &Client) -> Messages<'_> {
         Messages { client }
     }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -12,7 +12,7 @@ pub struct Models<'c> {
 }
 
 impl Models<'_> {
-    pub fn new(client: &Client) -> Models {
+    pub fn new(client: &Client) -> Models<'_> {
         Models { client }
     }
 

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -5,7 +5,7 @@ use async_anthropic::{
 };
 use async_trait::async_trait;
 use wiremock::{
-    matchers::{method, path},
+    matchers::{header, method, path},
     Mock, MockServer, ResponseTemplate,
 };
 
@@ -137,4 +137,36 @@ async fn test_error_handling_unauthorized() {
         "actual: {:?}",
         &result
     );
+}
+
+#[tokio::test]
+async fn test_user_agent_header() {
+    let server = TestSetup::setup().await;
+    let secret_key = "test_secret";
+
+    let expected_user_agent = concat!("async-anthropic/", env!("CARGO_PKG_VERSION"));
+
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .and(header("user-agent", expected_user_agent))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(&ListModelsResponse {
+                data: vec![],
+                first_id: None,
+                has_more: false,
+                last_id: None,
+            }),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .api_key(secret_key)
+        .base_url(server.uri())
+        .build()
+        .unwrap();
+
+    let result = client.models().list().await;
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
## Summary
- Adds `User-Agent: async-anthropic/{version}` header to all API requests using `reqwest::header::USER_AGENT`
- Version is derived at compile time via `CARGO_PKG_VERSION`
- Adds wiremock-based test validating the header is sent correctly

## Test plan
- [x] `cargo test` passes (12/12 tests)
- [x] `cargo fmt --all --check` passes
- [x] Clippy warnings are pre-existing on `main` (not introduced by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)